### PR TITLE
MeterianBot has fixed one issue in your codebase

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -59,11 +59,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
-                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
-            "markers": "python_version >= '3.4'",
-            "version": "==1.25.11"
+            "markers": "==1.26.14",
+            "version": "==1.26.14"
         }
     },
     "develop": {}


### PR DESCRIPTION
Hey! We’ve found issues with some of the libraries you are using in your project, **MeterianBot** managed to fix some of them for you but unfortunately not all of them. They just need your approval.

The security score of your project is **65**, the stability score **99** and the licensing score **100**.
You can have a more detailed look at the report [here](https://www.meterian.com/projects/?pid=6ea8f0f2-7154-4986-b0a0-e5c5a48ed8a2&branch=main&mode=eli).

## Fixes
We’ve updated **urllib3** **1.25.11** to **1.26.14** minor release because of **[CVE-2021-33503](https://nvd.nist.gov/vuln/details/CVE-2021-33503)**.

&nbsp;&nbsp;&nbsp;&nbsp;Threat severity: **HIGH** &nbsp;&nbsp;&nbsp;&nbsp; CVSS score: **7.5**
>When provided with a URL containing many @ characters in the authority component the authority regular expression exhibits catastrophic backtracking causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect.

---